### PR TITLE
Expose setInvalid for arbitrary validation message

### DIFF
--- a/xp-input-behavior.html
+++ b/xp-input-behavior.html
@@ -160,6 +160,23 @@ This behavior is used to add input capabilities on a custom element.
             return self;
         },
 
+        /**
+         * Sets invalid of adaptee to true or false
+         * 
+         * @method setInvalid 
+         * @param {string} [msg] 
+         * @param {boolean | Function} value
+         * @returns {Element}
+         */
+         setInvalid: function(msg, value) {
+             var self = this, _value;
+             if (value === undefined) { value = msg; msg = undefined; }
+             if (msg !== undefined) { self._setInvalidMessage(msg); }
+             _value = ( typeof value === 'function') ? value(self, self.isChanged, self.model) : value;
+             self._setInvalid(_value);
+             return self;
+         },
+         
         /*********************************************************************/
 
         /**


### PR DESCRIPTION
It's desirable to be able to validate input against external evaluators and set the invalid message through some arbitrary function.  There are a number of ways of doing this, I'm proposing exposing a setInvalid method that takes in a boolean expression or a function that it can call to get back a boolean value to determine whether or not the input is valid, this approach (hopefully) does not interfere with existing functionality.

Use-case:

```
    <mat-text-field name='password' id='pass1'></mat-text-field>
    <mat-text-field name='password' id='pass2' on-xp-input-change='checkPasswords'></mat-text-field>

    function checkPasswords(event) {
          self.isInvalid(function(element, isChanged, model) {
                return model !== element.parentElement.querySelector('#pass1').model;
          });
    }

```
